### PR TITLE
Drop deprecated OpenGLRenderer Props

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -148,19 +148,6 @@ ro.vendor.at_library=libqti-at.so
 ro.vendor.qti.core_ctl_min_cpu=2
 ro.vendor.qti.core_ctl_max_cpu=4
 
-#hwui properties
-ro.hwui.texture_cache_size=72
-ro.hwui.layer_cache_size=48
-ro.hwui.r_buffer_cache_size=8
-ro.hwui.path_cache_size=32
-ro.hwui.gradient_cache_size=1
-ro.hwui.drop_shadow_cache_size=6
-ro.hwui.texture_cache_flushrate=0.4
-ro.hwui.text_small_cache_width=1024
-ro.hwui.text_small_cache_height=1024
-ro.hwui.text_large_cache_width=2048
-ro.hwui.text_large_cache_height=2048
-
 #Bringup properties
 persist.vendor.radio.atfwd.start=true
 


### PR DESCRIPTION
These are the properties that you can use to control Android’s 2D hardware accelerated rendering pipeline and were dropped after android 8.0.
Reference:https://source.android.com/devices/graphics/renderer#openglrenderer-libhwui-properties