### PR TITLE
Fix time_daemon denies

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -37,7 +37,7 @@ TARGET_BOOTLOADER_BOARD_NAME :=sdm660
 TARGET_NO_BOOTLOADER := true
 
 # Kernel
-BOARD_KERNEL_CMDLINE := console=ttyMSM0,115200,n8 androidboot.console=ttyMSM0 earlycon=msm_serial_dm,0xc170000 androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x37 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 sched_enable_hmp=1 sched_enable_power_aware=1 service_locator.enable=1 swiotlb=1 loop.max_part=7
+BOARD_KERNEL_CMDLINE := console=ttyMSM0,115200,n8 androidboot.console=ttyMSM0 earlycon=msm_serial_dm,0xc170000 androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x37 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 sched_enable_hmp=1 sched_enable_power_aware=1 service_locator.enable=1 swiotlb=1 loop.max_part=16
 BOARD_KERNEL_CMDLINE += androidboot.avb_version=1.0 androidboot.vbmeta.avb_version=1.0
 BOARD_KERNEL_BASE        := 0x00000000
 BOARD_KERNEL_PAGESIZE    := 4096

--- a/aosp_lavender.mk
+++ b/aosp_lavender.mk
@@ -9,6 +9,9 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base_telephony.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/product_launched_with_p.mk)
 
+# Enable updating of APEXes
+$(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)
+
 # Inherit some common PixelExperience stuff
 $(call inherit-product, vendor/aosp/config/common_full_phone.mk)
 TARGET_BOOT_ANIMATION_RES := 1080

--- a/sepolicy/vendor/time_daemon.te
+++ b/sepolicy/vendor/time_daemon.te
@@ -1,1 +1,1 @@
-allow time_daemon self:capability { setgid setuid };
+allow time_daemon self:capability { setgid setuid dac_override dac_read_search };


### PR DESCRIPTION
```
05-19 14:02:50.912 27585 27585 W time_daemon: type=1400 audit(0.0:23061): avc: denied { dac_override } for capability=1 scontext=u:r:time_daemon:s0 tcontext=u:r:time_daemon:s0 tclass=capability permissive=0
05-19 14:02:50.912 27585 27585 W time_daemon: type=1400 audit(0.0:23062): avc: denied { dac_read_search } for capability=2 scontext=u:r:time_daemon:s0 tcontext=u:r:time_daemon:s0 tclass=capability permissive=0
```